### PR TITLE
Tiled Matrix multiplication update

### DIFF
--- a/kernels/tiledmatmul.S
+++ b/kernels/tiledmatmul.S
@@ -1,0 +1,42 @@
+tiledmatmul: 
+POP x1 // weight address
+POP x2 // input address
+POP x3 // result address
+POP x7 // n 
+POP x8 // k 
+POP x9 // m
+
+ld.i x10, x1       // Current weight tile address 
+ld.i x11, x2       // Current input tile address 
+ldi.i x4, 0        // Result tile row = weight tile row = 0 
+
+Loop_row: 
+ld.i x11, x2       // Reset x11 to 0,0 of input matrix 
+ldi.i x5, 0        // Result tile sum term index = weight tile column = 0 
+
+Loop_term_idx: 
+ld.m m0, x10       // Load new weight tile 
+ldi.i x6, 0        // Result tile column = 0 
+
+Loop_column: 
+ld.m m1, x11       // Load new input tile 
+addi.i, x3, x3, ?? // Find address of next partial sum from result memory
+ld.m m2, x3        // Load partial sum for column 
+gemm m3, m0, m1, m2 
+st.m m3, x3        // Save new partial sum back to result memory
+aadd.i x11, x11, ??// Move x11 to next col of input matrix –maybe 8nx8k so256 
+addi.i x6, x6, 1 
+bne x6, x9, Loop_column 
+
+addi.i x5, x5, 1 
+add.i x10, x10, ?? // Move x10 next column of weight matrix 
+add.i x11, x11, ?? // Move x11 to next row of input matrix 
+bne x5, x8, Loop_term_idx 
+
+                   // Result row is done
+addi.i x3, ??      // Find address to save next completed row 
+add.i x10, x10, ?? // Move x10 to next row of weight matrix 
+addi.i x4, x4, 1 
+bne x4, x7, Loop_row 
+
+halt

--- a/kernels/tiledmatmul.S
+++ b/kernels/tiledmatmul.S
@@ -16,11 +16,6 @@ mul.i x22, x22, 4   // x sys. arr. height
 mul.i x22, x22, 3   // x sys. arr. width - 1
 mul.i x22, x22, x9  // x m = memory offset to go down row in input matrix
 
-ldi.i x23, 2        //   Number of bytes in an element
-mul.i x23, x23, 4   // x sys. arr. height
-mul.i x23, x23, 3   // x sys. arr. width - 1
-mul.i x23, x23, x9  // x m = memory offset for output matrix tile [row (row 1), 0] -> [row + 1, 0]
-
 ldi.i x4, 0         // Temp result tile row = temp weight tile row = 0 
 
 Loop_row:  
@@ -47,7 +42,7 @@ addi.i x5, x5, 1
 bne x5, x8, Loop_term_idx 
 
                     // Result row is done
-add.i x12, x12, x23 // Find address to save next completed row 
+add.i x12, x12, x22 // Find address to save next completed row 
 add.i x10, x10, x21 // Move x10 to [row + 1, 0] of weight matrix 
 addi.i x4, x4, 1 
 bne x4, x7, Loop_row 

--- a/kernels/tiledmatmul.S
+++ b/kernels/tiledmatmul.S
@@ -1,50 +1,58 @@
 tiledmatmul:        // Y = W x I + B
-POP x10             // weight W address
-POP x20             // input  I address
-POP x12             // result Y address, where B is preloaded
-POP x7              // n
-POP x8              // k
-POP x9              // m
+// x10              // weight W address
+// x11              // input  I address
+mv.i x18, x11      
+// x12              // result Y address, where B is preloaded
+mv.i x19, x12
+// x13              // n
+// x14              // k
+// x15              // m
 
 ldi.i x21, 2        //   Number of bytes in an element
 mul.i x21, x21, 4   // x sys. arr. height
 mul.i x21, x21, 3   // x sys. arr. width - 1
-mul.i x21, x21, x8  // x k = memory offset for weight matrix tile [row (row 1), k] -> [row + 1, 0]
+mul.i x21, x21, x14 // x k = memory offset for next weight matrix tile [tile_row (matrix_row 1), 0] -> [tile_row + 1, 0]
 
 ldi.i x22, 2        //   Number of bytes in an element
 mul.i x22, x22, 4   // x sys. arr. height
 mul.i x22, x22, 3   // x sys. arr. width - 1
-mul.i x22, x22, x9  // x m = memory offset to go down row in input matrix
+mul.i x22, x22, x15 // x m = memory offset for next input matrix tile [tile_row (matrix_row 1), 0] -> [tile_row + 1, 0]
+
+ldi.i x23, 2        //   Number of bytes in an element
+mul.i x23, x23, 4   // x sys. arr. height
+mul.i x23, x23, 4   // x sys. arr. width
+mul.i x23, x23, x15 // x m = memory offset for next result matrix row
 
 ldi.i x4, 0         // Temp result tile row = temp weight tile row = 0 
 
 Loop_row:  
-ld.i x11, x20       // Reset x11 to [0, 0] of input matrix 
 ldi.i x5, 0         // Result tile sum term = weight tile column = 0 
+mv.i x11, x18       // Reset x11 to [0, 0] of input matrix 
 
 Loop_term_idx:  
-ld.m m1, x10        // Load new weight tile 
 ldi.i x6, 0         // Result tile column = 0 
+mv.i x12, x19       // Reset x12 to [row, 0] of result matrix
+ld.m m1, x10        // Load new weight tile 
 
 Loop_column: 
 ld.m m2, x11        // Load new input tile 
 ld.m m3, x12        // Load partial sum for column 
-addi.i, x12, x12, 8 // Find address of next partial sum from result memory
 gemm.m m3, m1, m2, m3 
 st.m m3, x12        // Save new partial sum back to result memory
 addi.i x11, x11, 8  // Move x11 to next column of input matrix
+addi.i x12, x12, 8  // Find address of next partial sum from result memory
 addi.i x6, x6, 1 
-bne x6, x9, Loop_column 
+bne x6, x15, Loop_column 
 
 addi.i x10, x10, 8  // Move x10 next column of weight matrix 
 add.i x11, x11, x22 // Move x11 to [row + 1, 0] of input matrix 
 addi.i x5, x5, 1 
-bne x5, x8, Loop_term_idx 
+bne x5, x14, Loop_term_idx 
 
                     // Result row is done
-add.i x12, x12, x22 // Find address to save next completed row 
+add.i x19, x19, x23 // Find address of next completed row 
 add.i x10, x10, x21 // Move x10 to [row + 1, 0] of weight matrix 
 addi.i x4, x4, 1 
-bne x4, x7, Loop_row 
+bne x4, x13, Loop_row 
 
-halt
+ret

--- a/kernels/tiledmatmul.S
+++ b/kernels/tiledmatmul.S
@@ -1,41 +1,50 @@
-tiledmatmul: 
-POP x1 // weight address
-POP x2 // input address
-POP x3 // result address
-POP x7 // n 
-POP x8 // k 
-POP x9 // m
+tiledmatmul:        // Y = W x I + B
+POP x10             // weight W address
+POP x20             // input  I address
+POP x12             // result Y address, where B is preloaded
+POP x7              // n
+POP x8              // k
+POP x9              // m
 
-ld.i x10, x1       // Current weight tile address 
-ld.i x11, x2       // Current input tile address 
-ldi.i x4, 0        // Result tile row = weight tile row = 0 
+ldi.i x21, 2        //   Number of bytes in an element
+mul.i x21, x21, 4   // x sys. arr. height
+mul.i x21, x21, 3   // x sys. arr. width - 1
+mul.i x21, x21, x8  // x k 
+addi.i x21, x21, 2  // + 2 = memory offset for weight matrix tile [row, k] -> [row + 1, 0]
 
-Loop_row: 
-ld.i x11, x2       // Reset x11 to 0,0 of input matrix 
-ldi.i x5, 0        // Result tile sum term index = weight tile column = 0 
+ldi.i x22, 2        //   Number of bytes in an element
+mul.i x22, x22, 4   // x sys. arr. height
+mul.i x22, x22, 4   // x sys. arr. width
+mul.i x22, x22, x9  // x m = memory offset to go down row in input matrix
 
-Loop_term_idx: 
-ld.m m0, x10       // Load new weight tile 
-ldi.i x6, 0        // Result tile column = 0 
+ldi.i x4, 0         // Temp result tile row = temp weight tile row = 0 
+
+Loop_row:  
+ld.i x11, x20       // Reset x11 to [0, 0] of input matrix 
+ldi.i x5, 0         // Temp result tile sum index = temp weight tile column = 0 
+
+Loop_term_idx:  
+ld.m m1, x10        // Load new weight tile 
+ldi.i x6, 0         // Result tile column = 0 
 
 Loop_column: 
-ld.m m1, x11       // Load new input tile 
-addi.i, x3, x3, ?? // Find address of next partial sum from result memory
-ld.m m2, x3        // Load partial sum for column 
-gemm m3, m0, m1, m2 
-st.m m3, x3        // Save new partial sum back to result memory
-aadd.i x11, x11, ??// Move x11 to next col of input matrix –maybe 8nx8k so256 
+ld.m m2, x11        // Load new input tile 
+addi.i, x12, x12, 2 // Find address of next partial sum from result memory
+ld.m m2, x12        // Load partial sum for column 
+gemm.m m3, m1, m2, m3 
+st.m m3, x12        // Save new partial sum back to result memory
+add.i x11, x11, 2   // Move x11 to next column of input matrix
 addi.i x6, x6, 1 
 bne x6, x9, Loop_column 
 
+add.i x10, x10, 2   // Move x10 next column of weight matrix 
+add.i x11, x11, x22 // Move x11 to next row of input matrix 
 addi.i x5, x5, 1 
-add.i x10, x10, ?? // Move x10 next column of weight matrix 
-add.i x11, x11, ?? // Move x11 to next row of input matrix 
 bne x5, x8, Loop_term_idx 
 
-                   // Result row is done
-addi.i x3, ??      // Find address to save next completed row 
-add.i x10, x10, ?? // Move x10 to next row of weight matrix 
+                    // Result row is done
+addi.i x12, 2       // Find address to save next completed row 
+add.i x10, x10, x21 // Move x10 to [row + 1, 0] of weight matrix 
 addi.i x4, x4, 1 
 bne x4, x7, Loop_row 
 

--- a/kernels/tiledmatmul.S
+++ b/kernels/tiledmatmul.S
@@ -8,29 +8,29 @@ mv.i x19, x12
 // x14              // k
 // x15              // m
 
-ldi.i x21, 2        //   Number of bytes in an element
+li.i x21, 2        //   Number of bytes in an element
 mul.i x21, x21, 4   // x sys. arr. height
 mul.i x21, x21, 3   // x sys. arr. width - 1
 mul.i x21, x21, x14 // x k = memory offset for next weight matrix tile [tile_row (matrix_row 1), 0] -> [tile_row + 1, 0]
 
-ldi.i x22, 2        //   Number of bytes in an element
+li.i x22, 2        //   Number of bytes in an element
 mul.i x22, x22, 4   // x sys. arr. height
 mul.i x22, x22, 3   // x sys. arr. width - 1
 mul.i x22, x22, x15 // x m = memory offset for next input matrix tile [tile_row (matrix_row 1), 0] -> [tile_row + 1, 0]
 
-ldi.i x23, 2        //   Number of bytes in an element
+li.i x23, 2        //   Number of bytes in an element
 mul.i x23, x23, 4   // x sys. arr. height
 mul.i x23, x23, 4   // x sys. arr. width
 mul.i x23, x23, x15 // x m = memory offset for next result matrix row
 
-ldi.i x4, 0         // Temp result tile row = temp weight tile row = 0 
+li.i x4, 0         // Temp result tile row = temp weight tile row = 0 
 
 Loop_row:  
-ldi.i x5, 0         // Result tile sum term = weight tile column = 0 
+li.i x5, 0         // Result tile sum term = weight tile column = 0 
 mv.i x11, x18       // Reset x11 to [0, 0] of input matrix 
 
 Loop_term_idx:  
-ldi.i x6, 0         // Result tile column = 0 
+li.i x6, 0         // Result tile column = 0 
 mv.i x12, x19       // Reset x12 to [row, 0] of result matrix
 ld.m m1, x10        // Load new weight tile 
 

--- a/kernels/tiledmatmul.S
+++ b/kernels/tiledmatmul.S
@@ -37,17 +37,17 @@ ld.m m3, x12        // Load partial sum for column
 addi.i, x12, x12, 8 // Find address of next partial sum from result memory
 gemm.m m3, m1, m2, m3 
 st.m m3, x12        // Save new partial sum back to result memory
-add.i x11, x11, 8   // Move x11 to next column of input matrix
+addi.i x11, x11, 8  // Move x11 to next column of input matrix
 addi.i x6, x6, 1 
 bne x6, x9, Loop_column 
 
-add.i x10, x10, 8   // Move x10 next column of weight matrix 
+addi.i x10, x10, 8  // Move x10 next column of weight matrix 
 add.i x11, x11, x22 // Move x11 to [row + 1, 0] of input matrix 
 addi.i x5, x5, 1 
 bne x5, x8, Loop_term_idx 
 
                     // Result row is done
-addi.i x12, x23     // Find address to save next completed row 
+add.i x12, x12, x23 // Find address to save next completed row 
 add.i x10, x10, x21 // Move x10 to [row + 1, 0] of weight matrix 
 addi.i x4, x4, 1 
 bne x4, x7, Loop_row 

--- a/kernels/tiledmatmul.S
+++ b/kernels/tiledmatmul.S
@@ -9,19 +9,23 @@ POP x9              // m
 ldi.i x21, 2        //   Number of bytes in an element
 mul.i x21, x21, 4   // x sys. arr. height
 mul.i x21, x21, 3   // x sys. arr. width - 1
-mul.i x21, x21, x8  // x k 
-addi.i x21, x21, 2  // + 2 = memory offset for weight matrix tile [row, k] -> [row + 1, 0]
+mul.i x21, x21, x8  // x k = memory offset for weight matrix tile [row (row 1), k] -> [row + 1, 0]
 
 ldi.i x22, 2        //   Number of bytes in an element
 mul.i x22, x22, 4   // x sys. arr. height
-mul.i x22, x22, 4   // x sys. arr. width
+mul.i x22, x22, 3   // x sys. arr. width - 1
 mul.i x22, x22, x9  // x m = memory offset to go down row in input matrix
+
+ldi.i x23, 2        //   Number of bytes in an element
+mul.i x23, x23, 4   // x sys. arr. height
+mul.i x23, x23, 3   // x sys. arr. width - 1
+mul.i x23, x23, x9  // x m = memory offset for output matrix tile [row (row 1), 0] -> [row + 1, 0]
 
 ldi.i x4, 0         // Temp result tile row = temp weight tile row = 0 
 
 Loop_row:  
 ld.i x11, x20       // Reset x11 to [0, 0] of input matrix 
-ldi.i x5, 0         // Temp result tile sum index = temp weight tile column = 0 
+ldi.i x5, 0         // Result tile sum term = weight tile column = 0 
 
 Loop_term_idx:  
 ld.m m1, x10        // Load new weight tile 
@@ -29,21 +33,21 @@ ldi.i x6, 0         // Result tile column = 0
 
 Loop_column: 
 ld.m m2, x11        // Load new input tile 
-addi.i, x12, x12, 2 // Find address of next partial sum from result memory
-ld.m m2, x12        // Load partial sum for column 
+ld.m m3, x12        // Load partial sum for column 
+addi.i, x12, x12, 8 // Find address of next partial sum from result memory
 gemm.m m3, m1, m2, m3 
 st.m m3, x12        // Save new partial sum back to result memory
-add.i x11, x11, 2   // Move x11 to next column of input matrix
+add.i x11, x11, 8   // Move x11 to next column of input matrix
 addi.i x6, x6, 1 
 bne x6, x9, Loop_column 
 
-add.i x10, x10, 2   // Move x10 next column of weight matrix 
-add.i x11, x11, x22 // Move x11 to next row of input matrix 
+add.i x10, x10, 8   // Move x10 next column of weight matrix 
+add.i x11, x11, x22 // Move x11 to [row + 1, 0] of input matrix 
 addi.i x5, x5, 1 
 bne x5, x8, Loop_term_idx 
 
                     // Result row is done
-addi.i x12, 2       // Find address to save next completed row 
+addi.i x12, x23     // Find address to save next completed row 
 add.i x10, x10, x21 // Move x10 to [row + 1, 0] of weight matrix 
 addi.i x4, x4, 1 
 bne x4, x7, Loop_row 


### PR DESCRIPTION
- Add support for bias term, Y = W x I + B
- Fix unknown memory allocations (clarification from memory team: matrices are stored row-column flattened)
- Fix use of reserved registers
- Fix typos
Note: does not account for potentially variable systolic array sizes or value size changes, currently assumes 4x4 FP16