### PR TITLE
Make new changes for new M type and GEMM type instructions

### DIFF
--- a/isa.md
+++ b/isa.md
@@ -41,10 +41,10 @@
 
 ## Matrix Instructions
 | Instr | Type | Name | Description
-| ----- |---- | ----------- | 
-| `ld.m` | M | Load Matrix | `md = M[rs1]` | 
-| `st.m` | M | Store Matrix | `M[rs1] = md` | 
-| `gemm.m` | M | Matrix Multiply | `md = ma @ mb + mc` | 
+| ----- |---- | ---- |----------- | 
+| `ld.m` | M | Load Matrix | `md = M[rs1 + imm]` | 
+| `st.m` | M | Store Matrix | `M[rs1 + imm] = md` | 
+| `gemm.m` | GEMM | Matrix Multiply | `md = ma @ mb + mc` | 
 
 ## Psuedo-instructions
 | Instr | Name | Description | Uses |
@@ -128,7 +128,7 @@
         <td>6 - 0</td>
     </tr>
     <tr>
-        <td>M</td>
+        <td>GEMM</td>
         <td><code>rd</code></td>
         <td><code>ra</code></td>
         <td><code>rb</code></td>
@@ -136,6 +136,22 @@
         <td>reserved</td>
         <td><code>opcode </code></td>
         <td><strong>meaningless register names</strong></td>
+    </tr>
+        <tr>
+        <td></td>
+        <td>31 - 28</td>
+        <td>27 - 23</td>
+        <td>22 - 18</td>
+        <td>17 - 7</td>
+        <td>6 - 0</td>
+    </tr>
+    <tr>
+        <td>M</td>
+        <td><code>rd</code></td>
+        <td><code>rs1</code></td>
+        <td><code>stride</code></td>
+        <td><code>Imm[10:0]</code></td>
+        <td><code>opcode</code></td>
     </tr>
 </table>
 

--- a/isa.md
+++ b/isa.md
@@ -6,45 +6,45 @@
 | int | `.i` | 32 bit signed integer | 
 
 ## Integer Instructions
-| Instr | Type | Name | Description | 
-| ----- | ---- | ---- | ----------- | 
-| `add.i` | R | ADD | `rd = rs1 + rs2` | 
-| `sub.i` | R | SUB | `rd = rs1 - rs2` | 
-| `xor.i` | R | XOR | `rd = rs1 ^ rs2` |
-| `or.i` | R | OR | `rd = rs1 OR rs2` |
-| `and.i` | R | AND | `rd = rs1 & rs2` | 
-| `sll.i` | R | Shift Left Logical | `rd = rs1 << rs2` |
-| `srl.i` | R | Shift Right Logical | `rd = rs1 >> rs2` |
-| `sra.i` | R | Shift Right Arith | `rd = rs1 >> rs2` |
-| `slt.i` | R | Set Less Than | `rd = (rs1 < rs2)?1:0` |
-| `sltu.i` | R | Set Less Than (U) | `rd = (rs1 < rs2)?1:0` |
-| `mul.i` | R | Multiply | `rd = (rs1 * rs2)[31:0]` | 
-| `mov.i` | R | Move | `rd = rs1` !NOT IN RISCV SPEC! | 
-| `addi.i` | I | ADD Immediate | `rd = rs1 + imm` | 
-| `xori.i` | I | XOR Immediate | `rd = rs1 ^ imm` |
-| `ori.i` | I | OR Immediate | `rd = rs1 OR imm` |
-| `andi.i` | I | AND Immediate | `rd = rs1 & imm` | 
-| `slli.i` | I | Shift Left Logical Imm| `rd = rs1 << imm[0:4]` |
-| `srli.i` | I | Shift Right Logical Imm| `rd = rs1 >> imm[0:4]` |
-| `srai.i` | I | Shift Right Arith Imm| `rd = rs1 >> imm[0:4]` |
-| `slti.i` | I | Set Less Than Imm | `rd = (rs1 < imm)?1:0` |
-| `sltui.i` | I | Set Less Than Imm (U) | `rd = (rs1 < imm)?1:0` |
-| `beq.i` | B | Branch == B | ` if(rs1 == rs2) PC += imm` |
-| `bne.i` | B | Branch != B | ` if(rs1 != rs2) PC += imm` |
-| `blt.i` | B | Branch < B  | `if(rs1 < rs2) PC += imm` |
-| `bge.i` | B | Branch ≥ B  | `if(rs1 >= rs2) PC += imm` |
-| `lw.i` | I | Load Word | `rd = M[rs1 + imm]` | 
-| `lui.i` | U | Load Upper Imm| `rd = imm << 12` | 
-| `sw.i` | S | Store Word | `M[rs1 + imm] = rd` | 
-| `jal` | UJ | Jump And Link | `rd = PC+4; PC += imm` |
-| `jalr`| I | Jump And Link Reg | `rd = PC+4; PC = rs1 + imm`|
+| Instr | Type | Name | Description | Opcode |
+| ----- | ---- | ---- | ----------- | ------ |
+| `add.i` | R | ADD | `rd = rs1 + rs2` | `0b0110011` |
+| `sub.i` | R | SUB | `rd = rs1 - rs2` | `0b0110011` |
+| `xor.i` | R | XOR | `rd = rs1 ^ rs2` |`0b0110011` |
+| `or.i` | R | OR | `rd = rs1 OR rs2` |`0b0110011` |
+| `and.i` | R | AND | `rd = rs1 & rs2` | `0b0110011` |
+| `sll.i` | R | Shift Left Logical | `rd = rs1 << rs2` |`0b0110011` |
+| `srl.i` | R | Shift Right Logical | `rd = rs1 >> rs2` |`0b0110011` |
+| `sra.i` | R | Shift Right Arith | `rd = rs1 >> rs2` |`0b0110011` |
+| `slt.i` | R | Set Less Than | `rd = (rs1 < rs2)?1:0` |`0b0110011` |
+| `sltu.i` | R | Set Less Than (U) | `rd = (rs1 < rs2)?1:0` |`0b0110011` |
+| `mul.i` | R | Multiply | `rd = (rs1 * rs2)[31:0]` | `0b0110011` |
+| `mov.i` | R | Move | `rd = rs1` !NOT IN RISCV SPEC! | `0b0110011` |
+| `addi.i` | I | ADD Immediate | `rd = rs1 + imm` | `0b0010011` |
+| `xori.i` | I | XOR Immediate | `rd = rs1 ^ imm` |`0b0010011` |
+| `ori.i` | I | OR Immediate | `rd = rs1 OR imm` |`0b0010011` |
+| `andi.i` | I | AND Immediate | `rd = rs1 & imm` | `0b0010011` |
+| `slli.i` | I | Shift Left Logical Imm| `rd = rs1 << imm[0:4]` | `0b0010011` |
+| `srli.i` | I | Shift Right Logical Imm| `rd = rs1 >> imm[0:4]` |`0b0010011` |
+| `srai.i` | I | Shift Right Arith Imm| `rd = rs1 >> imm[0:4]` |`0b0010011` |
+| `slti.i` | I | Set Less Than Imm | `rd = (rs1 < imm)?1:0` |`0b0010011` |
+| `sltui.i` | I | Set Less Than Imm (U) | `rd = (rs1 < imm)?1:0` |`0b0010011` |
+| `beq.i` | B | Branch == B | ` if(rs1 == rs2) PC += imm` |`0b1100011` |
+| `bne.i` | B | Branch != B | ` if(rs1 != rs2) PC += imm` |`0b1100011` |
+| `blt.i` | B | Branch < B  | `if(rs1 < rs2) PC += imm` |`0b1100011` |
+| `bge.i` | B | Branch ≥ B  | `if(rs1 >= rs2) PC += imm` |`0b1100011` |
+| `lw.i` | I | Load Word | `rd = M[rs1 + imm]` | `0b0000011` |
+| `lui.i` | U | Load Upper Imm| `rd = imm << 12` | `0b0110111` |
+| `sw.i` | S | Store Word | `M[rs1 + imm] = rd` | `0b0100011` |
+| `jal` | UJ | Jump And Link | `rd = PC+4; PC += imm` |`0b1101111` |
+| `jalr`| I | Jump And Link Reg | `rd = PC+4; PC = rs1 + imm`|`0b1100111` |
 
 ## Matrix Instructions
-| Instr | Type | Name | Description
-| ----- |---- | ---- |----------- | 
-| `ld.m` | M | Load Matrix | `md = M[rs1 + imm]` | 
-| `st.m` | M | Store Matrix | `M[rs1 + imm] = md` | 
-| `gemm.m` | GEMM | Matrix Multiply | `md = ma @ mb + mc` | 
+| Instr | Type | Name | Description | Opcode |
+| ----- |---- | ---- |----------- | ------ |
+| `ld.m` | M | Load Matrix | `md = M[rs1 + imm]` | `0b1000111` |
+| `st.m` | M | Store Matrix | `M[rs1 + imm] = md` | `0b1010111` |
+| `gemm.m` | GEMM | Matrix Multiply | `md = ma @ mb + mc` | `0b1110111` |
 
 ## Psuedo-instructions
 | Instr | Name | Description | Uses |


### PR DESCRIPTION
Distinguish between GEMM instruction type and M instruction type, used for loading and storing matrices to and from memory with a registered stride value. 